### PR TITLE
Corrected typo, shortened instruction

### DIFF
--- a/DailyQoute/main.cpp
+++ b/DailyQoute/main.cpp
@@ -24,8 +24,8 @@ void MainProgram() {
 			std::string qoute = json["content"].GetString();
 			std::string author = json["author"].GetString();
 			Console->Send("Random qoute:");
-			Console->Send(fmt::format("{0} \nBAuthor: {1}", qoute, author));
-			Console->Send("\nInput something random and press enter to get a new qoute", 10);
+			Console->Send(fmt::format("{0} \nAuthor: {1}", qoute, author));
+			Console->Send("\nPress enter to get a new qoute", 10);
 			Console->In();
 			MainProgram();
 			return;


### PR DESCRIPTION
Corrected typo 'Bauthor' into 'Author'
Changed instruction into 'press enter to get a new quote', because it's not necessary to input something random, as the previous instruction said.